### PR TITLE
Exposed RubyJS in the main package.json's export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.export = require('./ruby.js')
+module.exports = require('./ruby.js')


### PR DESCRIPTION
Made the following possible (in CS using commonJS):

```
{ R } = require('rubyjs')
```
